### PR TITLE
fix: Fixed the link to contributors.md file

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,7 @@ Fixes #(issue)
 
 <!-- Please remove all the irrelevant bullets to your PR -->
 
-- I haven't read the [contributing guide]()
+- I haven't read the [contributing guide](https://github.com/DhanrajKamble/ThePokedex/blob/master/CONTRIBUTING.MD)
 - My code doesn't follow the style guidelines of this project
 - I haven't commented my code, particularly in hard-to-understand areas
 - I haven't checked if my PR needs changes to the documentation


### PR DESCRIPTION
## What does this PR do?
It will fix the link to contributing.md file

Fixes #11 

![IMG-20231103-WA0001](https://github.com/DhanrajKamble/ThePokedex/assets/62764275/6c8d580f-bb3f-45c8-8899-2e267f5f2f83)


## Type of change

Fixed link to the contributor.md file

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Go to the ThePokedex repository
- Click on .github folder and click on PULL_REQUEST_TEMPLATE.MD file
- Scroll down to find checklist and click on contributing link
- It will not link to contributors.md file

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist